### PR TITLE
Fixed brackets mismatch in unquoted strings like "<a href={ url }>"

### DIFF
--- a/BracketGuard.py
+++ b/BracketGuard.py
@@ -103,7 +103,7 @@ class EventListener(sublime_plugin.EventListener):
       # workaround for the following code in markdown: ![example](img/example.png)
       markdownBracketScope = "punctuation.definition.string.begin.markdown"
 
-      if hasScope("string") and not hasScope(markdownBracketScope) or hasScope("comment"):
+      if hasScope("string") and not hasScope("unquoted") and not hasScope(markdownBracketScope) or hasScope("comment"):
         # ignore unmatched brackets in strings and comments
         continue
 

--- a/tests/testBracketGuard.py
+++ b/tests/testBracketGuard.py
@@ -35,6 +35,9 @@ class TestBracketGuard(TestCase):
 		openerRegions = self.insertCodeAndGetRegions("a(bc[defg{hijkl}mn])o")
 		self.assertEqual(len(openerRegions), 0)
 
+		openerRegions = self.insertCodeAndGetRegions("<a href={ url }>")
+		self.assertEqual(len(openerRegions), 0)
+
 
 	def testInvalidBracketsWrongCloser(self):
 


### PR DESCRIPTION
Hi, I found a bug in the plugin with Riot.js templates like `<a href={ url }></a>`, it was incorrectly highlighting the } bracket.

I fixed it but couldn't test it in Travis, there was some errors before my commit.

Also I'm not sure if I put a test in a correct place