### PR TITLE
Ignore for some views

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,23 @@
+sudo: required
 language: python
 python:
-    # this has nothing to do with ST 2/ ST 3, just leave it as 2.7
-    - "2.7"
+    - "3.6"
 
 env:
     global:
-        # Your package name
         - PACKAGE="BracketGuard"
-    matrix:
-        - SUBLIME_TEXT_VERSION="2"
         - SUBLIME_TEXT_VERSION="3"
+        - UNITTESTING_TAG="master"
 
 before_install:
-    - curl -OL https://raw.githubusercontent.com/randy3k/UnitTesting/master/sbin/travis.sh
+    - curl -OL https://raw.githubusercontent.com/SublimeText/UnitTesting/master/sbin/travis.sh
+    - if [ "$TRAVIS_OS_NAME" == "linux"  ]; then
+            export DISPLAY=:99.0;
+            sh -e /etc/init.d/xvfb start;
+      fi
 
 install:
     - sh travis.sh bootstrap
-
-before_script:
-    - export DISPLAY=:99.0
-    - sh -e /etc/init.d/xvfb start
 
 script:
     - sh travis.sh run_tests

--- a/BracketGuard.py
+++ b/BracketGuard.py
@@ -1,129 +1,130 @@
-import sublime, sublime_plugin
-import re, time
-
 from collections import namedtuple
+import time
+
+import sublime
+import sublime_plugin
+
 
 BracketPosition = namedtuple("BracketPosition", "position opener")
 BracketResult = namedtuple("BracketResult", "success start end")
 
 bracketGuardRegions = "BracketGuardRegions"
 
+
 class EventListener(sublime_plugin.EventListener):
+    def __init__(self):
+        self.latest_keypresses = {}
 
-  def __init__(self):
+    def on_modified(self, view):
+        if view.settings().get("is_test", False):
+            self.highlightBracketError(view)
 
-    self.latest_keypresses = {}
+    def on_modified_async(self, view):
+        self.clearRegions(view)
+        if self.doAutoCheck(view):
+            self.debounce(view, "modified", self.highlightBracketError)
 
+    def on_post_save_async(self, view):
+        if self.checkOnSave() and not self.doAutoCheck(view):
+            self.highlightBracketError(view)
 
-  def on_modified(self, view):
+    def clearRegions(self, view):
+        view.erase_regions(bracketGuardRegions)
 
-    if view.settings().get("is_test", False):
-      self.highlightBracketError(view)
+    def settings(self):
+        return sublime.load_settings("BracketGuard.sublime-settings")
 
+    def checkOnSave(self):
+        return self.settings().get("check_on_save")
 
-  def on_modified_async(self, view):
+    def doAutoCheck(self, view):
+        threshold = self.settings().get("file_length_threshold")
+        return threshold == -1 or threshold >= view.size()
 
-    self.clearRegions(view)
-    if self.doAutoCheck(view):
-       self.debounce(view, "modified", self.highlightBracketError)
+    def highlightBracketError(self, view):
+        bracketResult = self.getFirstBracketError(view)
 
-  def on_post_save_async(self, view):
+        if not bracketResult.success:
+            openerRegion = sublime.Region(
+                bracketResult.start, bracketResult.start + 1
+            )
+            closerRegion = sublime.Region(
+                bracketResult.end, bracketResult.end + 1
+            )
+            view.add_regions(
+                bracketGuardRegions, [openerRegion, closerRegion], "invalid"
+            )
 
-    if self.checkOnSave() and not self.doAutoCheck(view):
-      self.highlightBracketError(view)
+    def debounce(self, view, event_type, func):
+        key = (event_type, view.file_name())
+        this_keypress = time.time()
+        self.latest_keypresses[key] = this_keypress
+        debounceTime = self.settings().get("debounce_time", 500)
 
+        def callback():
+            latest_keypress = self.latest_keypresses.get(key, None)
+            if this_keypress == latest_keypress:
+                func(view)
 
-  def clearRegions(self, view):
+        sublime.set_timeout_async(callback, debounceTime)
 
-    view.erase_regions(bracketGuardRegions)
+    def getFirstBracketError(self, view):
+        opener = list("({[")
+        closer = list(")}]")
 
+        matchingStack = []
+        successResult = BracketResult(True, -1, -1)
+        codeStr = view.substr(sublime.Region(0, view.size()))
 
-  def settings(self):
+        for index, char in enumerate(codeStr):
 
-    return sublime.load_settings("BracketGuard.sublime-settings")
+            # this leaks memory ?
+            # if len(codeStr) != view.size():
+            #   return successResult
 
+            if char not in opener and char not in closer:
+                continue
 
-  def checkOnSave(self):
+            scopeName = view.scope_name(index)
+            hasScope = lambda s: s in scopeName
 
-    return self.settings().get("check_on_save")
+            # workaround for the following code in markdown: ![example](img/example.png)
+            markdownBracketScopeBegin = (
+                "punctuation.definition.string.begin.markdown"
+            )
+            markdownBracketScopeEnd = (
+                "punctuation.definition.string.end.markdown"
+            )
+            isMarkdownStringBeginOrEnd = (
+                lambda s: (
+                    hasScope(markdownBracketScopeBegin)
+                    or hasScope(markdownBracketScopeEnd)
+                )
+            )
 
+            if (
+                hasScope("string")
+                and not hasScope("unquoted")
+                and not isMarkdownStringBeginOrEnd(markdownBracketScopeBegin)
+                or hasScope("comment")
+            ):
+                # ignore unmatched brackets in strings and comments
+                continue
 
-  def doAutoCheck(self, view):
+            if char in opener:
+                matchingStack.append(BracketPosition(index, char))
+            elif char in closer:
+                matchingOpener = opener[closer.index(char)]
 
-    threshold = self.settings().get("file_length_threshold")
-    return threshold == -1 or threshold >= view.size()
+                if len(matchingStack) == 0:
+                    return BracketResult(False, -1, index)
 
-
-  def highlightBracketError(self, view):
-
-    bracketResult = self.getFirstBracketError(view)
-
-    if not bracketResult.success:
-      openerRegion = sublime.Region(bracketResult.start, bracketResult.start + 1)
-      closerRegion = sublime.Region(bracketResult.end, bracketResult.end + 1)
-      view.add_regions(bracketGuardRegions, [openerRegion, closerRegion], "invalid")
-
-
-  def debounce(self, view, event_type, func):
-
-    key = (event_type, view.file_name())
-    this_keypress = time.time()
-    self.latest_keypresses[key] = this_keypress
-    debounceTime = self.settings().get("debounce_time", 500)
-
-    def callback():
-        latest_keypress = self.latest_keypresses.get(key, None)
-        if this_keypress == latest_keypress:
-            func(view)
-
-    sublime.set_timeout_async(callback, debounceTime)
-
-
-  def getFirstBracketError(self, view):
-
-    opener = list("({[")
-    closer = list(")}]")
-
-    matchingStack = []
-    successResult = BracketResult(True, -1, -1)
-    codeStr = view.substr(sublime.Region(0, view.size()))
-
-    for index, char in enumerate(codeStr):
-
-      # this leaks memory ?
-      # if len(codeStr) != view.size():
-      #   return successResult
-
-      if char not in opener and not char in closer:
-        continue
-
-      scopeName = view.scope_name(index)
-      hasScope = lambda s: s in scopeName
-
-      # workaround for the following code in markdown: ![example](img/example.png)
-      markdownBracketScopeBegin = "punctuation.definition.string.begin.markdown"
-      markdownBracketScopeEnd = "punctuation.definition.string.end.markdown"
-      isMarkdownStringBeginOrEnd = lambda s: hasScope(markdownBracketScopeBegin) or hasScope(markdownBracketScopeEnd)
-
-      if hasScope("string") and not hasScope("unquoted") and not isMarkdownStringBeginOrEnd(markdownBracketScopeBegin) or hasScope("comment"):
-        # ignore unmatched brackets in strings and comments
-        continue
-
-      if char in opener:
-        matchingStack.append(BracketPosition(index, char))
-      elif char in closer:
-        matchingOpener = opener[closer.index(char)]
+                poppedOpener = matchingStack.pop()
+                if matchingOpener != poppedOpener.opener:
+                    return BracketResult(False, poppedOpener.position, index)
 
         if len(matchingStack) == 0:
-          return BracketResult(False, -1, index)
-
-        poppedOpener = matchingStack.pop()
-        if matchingOpener != poppedOpener.opener:
-          return BracketResult(False, poppedOpener.position, index)
-
-
-    if len(matchingStack) == 0:
-      return successResult
-    else:
-      poppedOpener = matchingStack.pop()
-      return BracketResult(False, poppedOpener.position, -1)
+            return successResult
+        else:
+            poppedOpener = matchingStack.pop()
+            return BracketResult(False, poppedOpener.position, -1)

--- a/BracketGuard.py
+++ b/BracketGuard.py
@@ -15,10 +15,6 @@ class EventListener(sublime_plugin.EventListener):
     def __init__(self):
         self.latest_keypresses = {}
 
-    def on_modified(self, view):
-        if view.settings().get("is_test", False):
-            self.highlightBracketError(view)
-
     def on_modified_async(self, view):
         self.clearRegions(view)
         if self.doAutoCheck(view):

--- a/BracketGuard.py
+++ b/BracketGuard.py
@@ -77,11 +77,6 @@ class EventListener(sublime_plugin.EventListener):
         codeStr = view.substr(sublime.Region(0, view.size()))
 
         for index, char in enumerate(codeStr):
-
-            # this leaks memory ?
-            # if len(codeStr) != view.size():
-            #   return successResult
-
             if char not in opener and char not in closer:
                 continue
 

--- a/BracketGuard.py
+++ b/BracketGuard.py
@@ -34,6 +34,14 @@ class EventListener(sublime_plugin.EventListener):
         return self.settings().get("check_on_save")
 
     def doAutoCheck(self, view):
+        if (
+            view.is_scratch()
+            or view.is_read_only()
+            or view.settings().get("repl")
+            or view.settings().get('is_widget')
+        ):
+            return False
+
         threshold = self.settings().get("file_length_threshold")
         return threshold == -1 or threshold >= view.size()
 

--- a/tests/testBracketGuard.py
+++ b/tests/testBracketGuard.py
@@ -3,64 +3,49 @@ from unittest import TestCase
 
 version = sublime.version()
 
+
 class TestBracketGuard(TestCase):
+    def setUp(self):
+        self.view = sublime.active_window().new_file()
+        self.view.settings().set("is_test", True)
 
-	def setUp(self):
+    def tearDown(self):
+        if self.view:
+            self.view.set_scratch(True)
+            self.view.close()
 
-		self.view = sublime.active_window().new_file()
-		self.view.settings().set("is_test", True)
+    def insertCodeAndGetRegions(self, code):
+        self.view.run_command("insert", {"characters": code})
+        return self.view.get_regions("BracketGuardRegions")
 
+    def testPureValidBrackets(self):
+        openerRegions = self.insertCodeAndGetRegions("([{}])")
+        self.assertEqual(len(openerRegions), 0)
 
-	def tearDown(self):
+    def testValidBracketsInCode(self):
+        openerRegions = self.insertCodeAndGetRegions("a(bc[defg{hijkl}mn])o")
+        self.assertEqual(len(openerRegions), 0)
 
-		if self.view:
-			self.view.set_scratch(True)
-			self.view.window().run_command("close_file")
+        openerRegions = self.insertCodeAndGetRegions("<a href={ url }>")
+        self.assertEqual(len(openerRegions), 0)
 
+    def testInvalidBracketsWrongCloser(self):
+        bracketGuardRegions = self.insertCodeAndGetRegions("({}])")
 
-	def insertCodeAndGetRegions(self, code):
+        self.assertEqual(len(bracketGuardRegions), 2)
+        self.assertEqual(bracketGuardRegions[0].a, 0)
+        self.assertEqual(bracketGuardRegions[1].a, 3)
 
-		self.view.run_command("insert", {"characters": code})
-		return self.view.get_regions("BracketGuardRegions")
+    def testInvalidBracketsNoCloser(self):
+        bracketGuardRegions = self.insertCodeAndGetRegions("({}")
 
+        self.assertEqual(len(bracketGuardRegions), 2)
+        self.assertEqual(bracketGuardRegions[0].a, -1)
+        self.assertEqual(bracketGuardRegions[1].a, 0)
 
-	def testPureValidBrackets(self):
+    def testInvalidBracketsNoOpener(self):
+        bracketGuardRegions = self.insertCodeAndGetRegions("){}")
 
-		openerRegions = self.insertCodeAndGetRegions("([{}])")
-		self.assertEqual(len(openerRegions), 0)
-
-
-	def testValidBracketsInCode(self):
-
-		openerRegions = self.insertCodeAndGetRegions("a(bc[defg{hijkl}mn])o")
-		self.assertEqual(len(openerRegions), 0)
-
-		openerRegions = self.insertCodeAndGetRegions("<a href={ url }>")
-		self.assertEqual(len(openerRegions), 0)
-
-
-	def testInvalidBracketsWrongCloser(self):
-
-		bracketGuardRegions = self.insertCodeAndGetRegions("({}])")
-
-		self.assertEqual(len(bracketGuardRegions), 2)
-		self.assertEqual(bracketGuardRegions[0].a, 0)
-		self.assertEqual(bracketGuardRegions[1].a, 3)
-
-
-	def testInvalidBracketsNoCloser(self):
-
-		bracketGuardRegions = self.insertCodeAndGetRegions("({}")
-
-		self.assertEqual(len(bracketGuardRegions), 2)
-		self.assertEqual(bracketGuardRegions[0].a, -1)
-		self.assertEqual(bracketGuardRegions[1].a, 0)
-
-
-	def testInvalidBracketsNoOpener(self):
-
-		bracketGuardRegions = self.insertCodeAndGetRegions("){}")
-
-		self.assertEqual(len(bracketGuardRegions), 2)
-		self.assertEqual(bracketGuardRegions[0].a, -1)
-		self.assertEqual(bracketGuardRegions[1].a, 0)
+        self.assertEqual(len(bracketGuardRegions), 2)
+        self.assertEqual(bracketGuardRegions[0].a, -1)
+        self.assertEqual(bracketGuardRegions[1].a, 0)

--- a/unittesting.json
+++ b/unittesting.json
@@ -1,0 +1,5 @@
+{
+    "deferred": true,
+    "legacy_runner": false,
+    // "capture_console": true,
+}


### PR DESCRIPTION
- Autoformatted the code using 'black' autoformatter
- Removed the test shortcut, t.i. the tests are now running through the debouncer
- Ignore scratch, read-only views, and widgets.

That is basically so that the plugin does not annotate git diff views or error panels from SublimeLinter/LSP etc.